### PR TITLE
Fix Json.stringify parameters for use with newer versions of wing compiler

### DIFF
--- a/main.w
+++ b/main.w
@@ -229,7 +229,7 @@ api.get("/leaderboard", inflight (_) => {
 // Select the winner between a pair of options
 api.post("/selectWinner", inflight (req) => {
   let body = Json.parse(req.body ?? "");
-  log(Json.stringify(body, {indent: 2}));
+  log(Json.stringify(body, indent: 2));
   let selections = SelectWinnerRequest.fromJson(body);
 
   let var newScores = Array<num>[];

--- a/main.w
+++ b/main.w
@@ -229,7 +229,7 @@ api.get("/leaderboard", inflight (_) => {
 // Select the winner between a pair of options
 api.post("/selectWinner", inflight (req) => {
   let body = Json.parse(req.body ?? "");
-  log(Json.stringify(body, 2));
+  log(Json.stringify(body, {indent: 2}));
   let selections = SelectWinnerRequest.fromJson(body);
 
   let var newScores = Array<num>[];


### PR DESCRIPTION
Fix `Json.stringify(..)` parameters in sample, for use with newer versions of wing compiler:

```
$ wing compile --target tf-aws voting-app/main.w

error: Expected type to be "JsonStringifyOptions?", but got "num" instead
    --> voting-app/main.w:232:28
    |
232 |   log(Json.stringify(body, 2));
    |                            ^ Expected type to be "JsonStringifyOptions?", but got "num" instead
```

wing version:
```
$ wing --version
0.26.7
```

---

Another alternative would be to remove the parameter altogether, to make the sample code backward-compatible with older `wing` versions. Not sure what would be preferable from your perspective?

---

/cc @Chriscbr @skorfmann 